### PR TITLE
feat: Add profile picture URL and custom fields to Person model

### DIFF
--- a/backend/backend_tasks.md
+++ b/backend/backend_tasks.md
@@ -18,12 +18,12 @@ This section focuses on enriching the existing data models and related API endpo
   Files to Update: `models.py`, `services/person_service.py`, `blueprints/people.py`.  
   Action: Include database migration.
 
-- **Task 1.3: Add Profile Picture URL to Person Model**  
+- **DONE - Task 1.3: Add Profile Picture URL to Person Model**  
   Description: Add `profile_picture_url` (String). Actual file upload is a separate feature (see II.A).  
   Files to Update: `models.py`, `services/person_service.py`, `blueprints/people.py`.  
   Action: Include database migration.
 
-- **Task 1.4: Implement Custom Fields/Tags for Persons**  
+- **DONE - Task 1.4: Implement Custom Fields/Tags for Persons**  
   Description: Allow users to add custom key-value attributes to a person.  
   Design Choice: JSONB field in Person model or a separate PersonCustomField table.  
   Files to Update: `models.py`, `services/person_service.py`, `blueprints/people.py`.  

--- a/backend/migrations/versions/0001_add_profile_picture_url_to_person.py
+++ b/backend/migrations/versions/0001_add_profile_picture_url_to_person.py
@@ -1,0 +1,24 @@
+"""add_profile_picture_url_to_person
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-04-08 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None  # Assuming this is the first migration
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('people', sa.Column('profile_picture_url', sa.String(length=512), nullable=True))
+
+
+def downgrade():
+    op.drop_column('people', 'profile_picture_url')

--- a/backend/migrations/versions/0002_add_custom_fields_to_person.py
+++ b/backend/migrations/versions/0002_add_custom_fields_to_person.py
@@ -1,0 +1,24 @@
+"""add_custom_fields_to_person
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-04-08 12:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('people', sa.Column('custom_fields', postgresql.JSONB(astext_type=sa.Text()), nullable=True, server_default=sa.text("'{}'::jsonb")))
+
+
+def downgrade():
+    op.drop_column('people', 'custom_fields')

--- a/backend/models.py
+++ b/backend/models.py
@@ -187,6 +187,8 @@ class Person(Base):
     created_by = Column(PG_UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
     created_at = Column(DateTime, default=datetime.utcnow, index=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    profile_picture_url = Column(String(512))  # Added profile_picture_url field
+    custom_fields = Column(JSONB, nullable=True, default=dict)  # Added custom_fields
 
     def to_dict(self):
         return {"id": str(self.id), "tree_id": str(self.tree_id), "first_name": self.first_name,
@@ -200,6 +202,8 @@ class Person(Base):
             "place_of_death": self.place_of_death,
             "burial_place": self.burial_place, "privacy_level": self.privacy_level.value,
             "is_living": self.is_living, "notes": self.notes, "biography": self.biography, "custom_attributes": self.custom_attributes,
+            "profile_picture_url": self.profile_picture_url,  # Added to to_dict
+            "custom_fields": self.custom_fields,  # Added custom_fields to to_dict
             "created_by": str(self.created_by),
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None}

--- a/backend/services/person_service.py
+++ b/backend/services/person_service.py
@@ -136,7 +136,9 @@ def create_person_db(db: DBSession, user_id: uuid.UUID, tree_id: uuid.UUID, pers
             is_living=person_data.get('is_living'), # Will be auto-set if None
             notes=person_data.get('notes'),
             biography=person_data.get('biography'),
-            custom_attributes=person_data.get('custom_attributes', {})
+            custom_attributes=person_data.get('custom_attributes', {}),
+            profile_picture_url=person_data.get('profile_picture_url'),  # Added profile_picture_url
+            custom_fields=person_data.get('custom_fields', {})  # Added custom_fields
         )
         # If is_living is not explicitly provided, determine it based on death_date.
         if new_person.is_living is None:
@@ -168,7 +170,9 @@ def update_person_db(db: DBSession, person_id: uuid.UUID, tree_id: uuid.UUID, pe
         'first_name', 'middle_names', 'last_name', 'maiden_name', 'nickname', 'gender',
         'birth_date', 'birth_date_approx', 'birth_place', 'place_of_birth', 
         'death_date', 'death_date_approx', 'death_place', 'place_of_death', 
-        'burial_place', 'privacy_level', 'is_living', 'notes', 'biography', 'custom_attributes'
+        'burial_place', 'privacy_level', 'is_living', 'notes', 'biography', 'custom_attributes',
+        'profile_picture_url',  # Added profile_picture_url to allowed fields
+        'custom_fields'  # Added custom_fields to allowed fields
     ]
 
     for field, value in person_data.items():
@@ -188,6 +192,10 @@ def update_person_db(db: DBSession, person_id: uuid.UUID, tree_id: uuid.UUID, pe
             elif field == 'custom_attributes':
                  if not isinstance(value, dict) and value is not None: 
                      validation_errors[field] = "Custom attributes must be a dictionary or null."
+                 else: setattr(person, field, value if value is not None else {}) # Default to empty dict if null
+            elif field == 'custom_fields':  # Added custom_fields handling
+                 if not isinstance(value, dict) and value is not None:
+                     validation_errors[field] = "Custom fields must be a dictionary or null."
                  else: setattr(person, field, value if value is not None else {}) # Default to empty dict if null
             elif field in ['is_living', 'birth_date_approx', 'death_date_approx']:
                  if not isinstance(value, bool) and value is not None: 

--- a/backend/tests/test_people_api.py
+++ b/backend/tests/test_people_api.py
@@ -1,0 +1,202 @@
+import unittest
+import json
+import uuid
+from unittest.mock import patch, MagicMock
+
+from flask import Flask, jsonify, g, session
+
+# Assuming your blueprint and service are importable
+# Adjust paths as necessary
+from blueprints.people import people_bp 
+# Import the actual services that will be mocked
+import services.person_service as person_service_module
+
+class TestPeopleAPI(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(people_bp)
+        self.app.config['TESTING'] = True
+        self.client = self.app.test_client()
+
+        # Mock session and g for decorators and user context
+        # self.app.before_request(self.mock_before_request)
+        
+        self.test_user_id = str(uuid.uuid4())
+        self.test_tree_id = str(uuid.uuid4())
+        self.test_person_id = str(uuid.uuid4())
+
+        # Patch the actual service functions used by the blueprint endpoints
+        self.patcher_create_person_db = patch('blueprints.people.create_person_db')
+        self.patcher_update_person_db = patch('blueprints.people.update_person_db')
+        self.patcher_get_person_db = patch('blueprints.people.get_person_db') # If needed for PUT setup
+        self.patcher_require_tree_access = patch('blueprints.people.require_tree_access')
+
+
+        self.mock_create_person_db = self.patcher_create_person_db.start()
+        self.mock_update_person_db = self.patcher_update_person_db.start()
+        self.mock_get_person_db = self.patcher_get_person_db.start()
+        self.mock_require_tree_access = self.patcher_require_tree_access.start()
+        
+        # Configure the decorator mock to just run the decorated function
+        self.mock_require_tree_access.side_effect = lambda level: (lambda func: func)
+
+
+    def tearDown(self):
+        self.patcher_create_person_db.stop()
+        self.patcher_update_person_db.stop()
+        self.patcher_get_person_db.stop()
+        self.patcher_require_tree_access.stop()
+
+
+    def test_create_person_endpoint_with_new_fields(self):
+        person_data_to_send = {
+            "first_name": "ApiTest", "last_name": "User",
+            "profile_picture_url": "http://api.example.com/profile.jpg",
+            "custom_fields": {"department": "api_dev", "employee_id": "A123"}
+        }
+        
+        # Mock the service layer response
+        mock_service_response = {
+            "id": self.test_person_id, 
+            **person_data_to_send # Service should return the data as saved
+        }
+        self.mock_create_person_db.return_value = mock_service_response
+
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = self.test_user_id
+                sess['active_tree_id'] = self.test_tree_id # For @require_tree_access if it checks session
+
+            # Simulate g.db and g.active_tree_id if @require_tree_access uses them directly
+            # This is a bit of a workaround for not having full app context.
+            # A better way might involve a custom test app_context processor.
+            with self.app.test_request_context('/api/people', method='POST'):
+                if hasattr(g, 'db'): g.db = MagicMock() 
+                if hasattr(g, 'active_tree_id'): g.active_tree_id = self.test_tree_id
+
+
+                response = client.post('/api/people', json=person_data_to_send)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json, mock_service_response)
+        self.mock_create_person_db.assert_called_once_with(
+            ANY, # db session mock
+            uuid.UUID(self.test_user_id), 
+            uuid.UUID(self.test_tree_id), 
+            person_data_to_send
+        )
+
+    def test_create_person_endpoint_without_new_fields(self):
+        person_data_to_send = {"first_name": "ApiSimple", "last_name": "User"}
+        
+        mock_service_response = {
+            "id": self.test_person_id, 
+            **person_data_to_send,
+            "profile_picture_url": None, # Expected default
+            "custom_fields": {}          # Expected default
+        }
+        self.mock_create_person_db.return_value = mock_service_response
+
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = self.test_user_id
+                sess['active_tree_id'] = self.test_tree_id
+            
+            with self.app.test_request_context('/api/people', method='POST'):
+                 if hasattr(g, 'db'): g.db = MagicMock() 
+                 if hasattr(g, 'active_tree_id'): g.active_tree_id = self.test_tree_id
+
+                 response = client.post('/api/people', json=person_data_to_send)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json, mock_service_response)
+
+
+    def test_update_person_endpoint_with_new_fields(self):
+        update_data_to_send = {
+            "profile_picture_url": "http://updated.com/new_profile.png",
+            "custom_fields": {"status": "promoted", "office": "corner"}
+        }
+        
+        mock_service_response = {
+            "id": self.test_person_id, 
+            "first_name": "OriginalName", # Assuming some original data
+            **update_data_to_send
+        }
+        self.mock_update_person_db.return_value = mock_service_response
+
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = self.test_user_id
+                sess['active_tree_id'] = self.test_tree_id
+
+            with self.app.test_request_context(f'/api/people/{self.test_person_id}', method='PUT'):
+                 if hasattr(g, 'db'): g.db = MagicMock()
+                 if hasattr(g, 'active_tree_id'): g.active_tree_id = self.test_tree_id
+            
+                 response = client.put(f'/api/people/{self.test_person_id}', json=update_data_to_send)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, mock_service_response)
+        self.mock_update_person_db.assert_called_once_with(
+            ANY, # db session mock
+            uuid.UUID(self.test_person_id), 
+            uuid.UUID(self.test_tree_id), 
+            update_data_to_send
+        )
+
+    def test_update_person_endpoint_clear_fields(self):
+        update_data_to_send = {
+            "profile_picture_url": None,
+            "custom_fields": {}
+        }
+        
+        mock_service_response = {
+            "id": self.test_person_id,
+            "first_name": "OriginalName",
+            "profile_picture_url": None, # Updated value
+            "custom_fields": {}          # Updated value
+        }
+        self.mock_update_person_db.return_value = mock_service_response
+
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = self.test_user_id
+                sess['active_tree_id'] = self.test_tree_id
+            
+            with self.app.test_request_context(f'/api/people/{self.test_person_id}', method='PUT'):
+                if hasattr(g, 'db'): g.db = MagicMock()
+                if hasattr(g, 'active_tree_id'): g.active_tree_id = self.test_tree_id
+
+                response = client.put(f'/api/people/{self.test_person_id}', json=update_data_to_send)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, mock_service_response)
+
+    # Example of testing validation (if blueprint were to do it, but service handles it)
+    # For this setup, we assume the service layer (mocked here) would raise HTTPException for bad data
+    def test_update_person_endpoint_invalid_custom_fields_type(self):
+        update_data_to_send = {"custom_fields": "not_a_dictionary"}
+        
+        # Simulate the service layer raising an HTTPException (e.g., BadRequest 400)
+        # This is what the actual service would do, and the blueprint would propagate it.
+        self.mock_update_person_db.side_effect = BadRequest(description="Custom fields must be a dictionary or null.")
+
+        with self.client as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = self.test_user_id
+                sess['active_tree_id'] = self.test_tree_id
+
+            with self.app.test_request_context(f'/api/people/{self.test_person_id}', method='PUT'):
+                if hasattr(g, 'db'): g.db = MagicMock()
+                if hasattr(g, 'active_tree_id'): g.active_tree_id = self.test_tree_id
+            
+                response = client.put(f'/api/people/{self.test_person_id}', json=update_data_to_send)
+
+        self.assertEqual(response.status_code, 400) # Werkzeug's BadRequest maps to 400
+        self.assertIn("Custom fields must be a dictionary or null", response.get_data(as_text=True))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_person_service.py
+++ b/backend/tests/test_person_service.py
@@ -1,0 +1,215 @@
+import unittest
+from unittest.mock import MagicMock, patch, call, ANY
+import uuid
+from datetime import date
+
+from sqlalchemy.orm import Session as DBSession
+from werkzeug.exceptions import HTTPException, NotFound, BadRequest
+
+# Assuming your project structure allows this import path
+# Adjust if your models/services are in a different relative path
+from models import Person, PrivacyLevelEnum, User # Assuming User is needed for created_by
+from services.person_service import (
+    create_person_db,
+    update_person_db
+    # get_person_db, # Add if testing get
+    # get_all_people_db, # Add if testing get_all
+    # delete_person_db # Add if testing delete
+)
+# If _get_or_404 or _handle_sqlalchemy_error are used directly and need mocking from utils
+# from utils import _get_or_404, _handle_sqlalchemy_error
+
+class TestPersonService(unittest.TestCase):
+
+    def setUp(self):
+        # Common setup for tests, e.g., mock DB session
+        self.mock_db_session = MagicMock(spec=DBSession)
+        self.test_user_id = uuid.uuid4()
+        self.test_tree_id = uuid.uuid4()
+        self.test_person_id = uuid.uuid4()
+
+        # Mock user for created_by
+        self.mock_user = MagicMock(spec=User)
+        self.mock_user.id = self.test_user_id
+
+    @patch('services.person_service.Person') # Mock the Person model class
+    def test_create_person_db_with_all_new_fields(self, MockPerson):
+        mock_person_instance = MockPerson.return_value
+        mock_person_instance.to_dict.return_value = {"id": str(self.test_person_id), "first_name": "Test"} # Mock to_dict
+
+        person_data = {
+            "first_name": "Test", "last_name": "User",
+            "profile_picture_url": "http://example.com/profile.jpg",
+            "custom_fields": {"hobby": "testing", "skill": "mocking"}
+        }
+        
+        created_person = create_person_db(self.mock_db_session, self.test_user_id, self.test_tree_id, person_data)
+
+        MockPerson.assert_called_once_with(
+            tree_id=self.test_tree_id, created_by=self.test_user_id,
+            first_name="Test", last_name="User",
+            middle_names=None, maiden_name=None, nickname=None, gender=None,
+            birth_date=None, birth_date_approx=False, birth_place=None, place_of_birth=None,
+            death_date=None, death_date_approx=False, death_place=None, place_of_death=None,
+            burial_place=None, privacy_level=PrivacyLevelEnum.inherit,
+            is_living=True, # Default when death_date is None
+            notes=None, biography=None, custom_attributes={},
+            profile_picture_url="http://example.com/profile.jpg",
+            custom_fields={"hobby": "testing", "skill": "mocking"}
+        )
+        self.mock_db_session.add.assert_called_once_with(mock_person_instance)
+        self.mock_db_session.commit.assert_called_once()
+        self.mock_db_session.refresh.assert_called_once_with(mock_person_instance)
+        self.assertEqual(created_person, mock_person_instance.to_dict.return_value)
+
+    @patch('services.person_service.Person')
+    def test_create_person_db_with_profile_url_only(self, MockPerson):
+        mock_person_instance = MockPerson.return_value
+        person_data = {
+            "first_name": "Test",
+            "profile_picture_url": "http://example.com/pic.png"
+        }
+        create_person_db(self.mock_db_session, self.test_user_id, self.test_tree_id, person_data)
+        args, kwargs = MockPerson.call_args
+        self.assertEqual(kwargs.get('profile_picture_url'), "http://example.com/pic.png")
+        self.assertEqual(kwargs.get('custom_fields'), {}) # Should default to empty dict
+
+    @patch('services.person_service.Person')
+    def test_create_person_db_with_custom_fields_only(self, MockPerson):
+        mock_person_instance = MockPerson.return_value
+        person_data = {
+            "first_name": "Test",
+            "custom_fields": {"department": "dev"}
+        }
+        create_person_db(self.mock_db_session, self.test_user_id, self.test_tree_id, person_data)
+        args, kwargs = MockPerson.call_args
+        self.assertIsNone(kwargs.get('profile_picture_url')) # Should default to None
+        self.assertEqual(kwargs.get('custom_fields'), {"department": "dev"})
+
+    @patch('services.person_service.Person')
+    def test_create_person_db_with_neither_new_field(self, MockPerson):
+        mock_person_instance = MockPerson.return_value
+        person_data = {"first_name": "Test"}
+        create_person_db(self.mock_db_session, self.test_user_id, self.test_tree_id, person_data)
+        args, kwargs = MockPerson.call_args
+        self.assertIsNone(kwargs.get('profile_picture_url'))
+        self.assertEqual(kwargs.get('custom_fields'), {})
+
+    @patch('services.person_service._get_or_404') # Mock _get_or_404 to return a mock Person
+    def test_update_person_db_profile_url_and_custom_fields(self, mock_get_or_404):
+        mock_person = MagicMock(spec=Person)
+        mock_person.id = self.test_person_id
+        mock_person.tree_id = self.test_tree_id
+        # Set initial values for fields that might be auto-updated based on others (like is_living)
+        mock_person.birth_date = date(1990, 1, 1)
+        mock_person.death_date = None
+        mock_person.is_living = True
+        mock_person.privacy_level = PrivacyLevelEnum.inherit # Ensure it has a privacy_level
+        mock_person.custom_attributes = {} # Ensure it has custom_attributes
+        mock_person.profile_picture_url = None
+        mock_person.custom_fields = {}
+
+        mock_get_or_404.return_value = mock_person
+        mock_person.to_dict.return_value = {"id": str(self.test_person_id), "first_name": "Updated Name"}
+
+        update_data = {
+            "first_name": "Updated Name",
+            "profile_picture_url": "http://new.com/new.jpg",
+            "custom_fields": {"status": "active", "id": 123}
+        }
+        
+        updated_person_dict = update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data)
+
+        mock_get_or_404.assert_called_once_with(self.mock_db_session, Person, self.test_person_id, tree_id=self.test_tree_id)
+        self.assertEqual(mock_person.first_name, "Updated Name")
+        self.assertEqual(mock_person.profile_picture_url, "http://new.com/new.jpg")
+        self.assertEqual(mock_person.custom_fields, {"status": "active", "id": 123})
+        
+        self.mock_db_session.commit.assert_called_once()
+        self.mock_db_session.refresh.assert_called_once_with(mock_person)
+        self.assertEqual(updated_person_dict, mock_person.to_dict.return_value)
+
+    @patch('services.person_service._get_or_404')
+    def test_update_person_db_clear_profile_url(self, mock_get_or_404):
+        mock_person = MagicMock(spec=Person)
+        mock_person.profile_picture_url = "http://old.com/old.jpg"
+        # Set other required fields for update logic
+        mock_person.birth_date = None 
+        mock_person.death_date = None
+        mock_person.is_living = True
+        mock_person.privacy_level = PrivacyLevelEnum.inherit
+        mock_person.custom_attributes = {}
+        mock_person.custom_fields = {}
+        mock_get_or_404.return_value = mock_person
+        
+        update_data = {"profile_picture_url": None}
+        update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data)
+        self.assertIsNone(mock_person.profile_picture_url)
+
+    @patch('services.person_service._get_or_404')
+    def test_update_person_db_update_custom_fields(self, mock_get_or_404):
+        mock_person = MagicMock(spec=Person)
+        mock_person.custom_fields = {"old_key": "old_value"}
+        # Set other required fields
+        mock_person.birth_date = None
+        mock_person.death_date = None
+        mock_person.is_living = True
+        mock_person.privacy_level = PrivacyLevelEnum.inherit
+        mock_person.custom_attributes = {}
+        mock_person.profile_picture_url = None
+        mock_get_or_404.return_value = mock_person
+        
+        update_data = {"custom_fields": {"new_key": "new_value", "old_key": "updated_value"}}
+        update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data)
+        self.assertEqual(mock_person.custom_fields, {"new_key": "new_value", "old_key": "updated_value"})
+
+    @patch('services.person_service._get_or_404')
+    def test_update_person_db_clear_custom_fields(self, mock_get_or_404):
+        mock_person = MagicMock(spec=Person)
+        mock_person.custom_fields = {"old_key": "old_value"}
+        # Set other required fields
+        mock_person.birth_date = None
+        mock_person.death_date = None
+        mock_person.is_living = True
+        mock_person.privacy_level = PrivacyLevelEnum.inherit
+        mock_person.custom_attributes = {}
+        mock_person.profile_picture_url = None
+        mock_get_or_404.return_value = mock_person
+
+        update_data_empty_dict = {"custom_fields": {}}
+        update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data_empty_dict)
+        self.assertEqual(mock_person.custom_fields, {})
+        
+        # Test setting to None also results in empty dict
+        mock_person.custom_fields = {"another_key": "another_value"} # Reset for next part
+        update_data_none = {"custom_fields": None}
+        update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data_none)
+        self.assertEqual(mock_person.custom_fields, {})
+
+
+    @patch('services.person_service._get_or_404')
+    def test_update_person_db_custom_fields_validation_not_dict(self, mock_get_or_404):
+        mock_person = MagicMock(spec=Person)
+        # Set other required fields
+        mock_person.birth_date = None
+        mock_person.death_date = None
+        mock_person.is_living = True
+        mock_person.privacy_level = PrivacyLevelEnum.inherit
+        mock_person.custom_attributes = {}
+        mock_person.profile_picture_url = None
+        mock_person.custom_fields = {}
+        mock_get_or_404.return_value = mock_person
+        
+        update_data = {"custom_fields": "not a dictionary"}
+        with self.assertRaises(HTTPException) as context: # werkzeug.exceptions.BadRequest (subclass of HTTPException)
+            update_person_db(self.mock_db_session, self.test_person_id, self.test_tree_id, update_data)
+        
+        self.assertEqual(context.exception.code, 400)
+        # Assuming the service function aborts with a specific structure
+        # self.assertIn("Custom fields must be a dictionary or null", context.exception.description.get("details").get("custom_fields"))
+        # More robust check if abort description structure changes:
+        self.assertTrue(any("Custom fields must be a dictionary or null" in str(err) for err in context.exception.description.get("details", {}).values()))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces two enhancements to the Person model:

1.  **Profile Picture URL (`profile_picture_url`)**:
    *   I added `profile_picture_url` (String) to the `Person` model in `models.py`.
    *   I updated `person_service.py` to handle this field during creation and updates.
    *   I created an Alembic migration `0001_add_profile_picture_url_to_person.py`.

2.  **Custom Fields/Tags (`custom_fields`)**:
    *   I added `custom_fields` (JSONB) to the `Person` model in `models.py`.
    *   I updated `person_service.py` to manage these custom key-value attributes.
    *   I created an Alembic migration `0002_add_custom_fields_to_person.py`.

**Testing**:
*   I added new unit tests in `backend/tests/test_person_service.py` for the service layer changes.
*   I added new integration tests in `backend/tests/test_people_api.py` for the API endpoints.
*   These tests cover various scenarios for creating and updating persons with the new fields.

**Documentation**:
*   I marked tasks 1.3 and 1.4 as "DONE" in `backend/backend_tasks.md`.

The Alembic migration scripts were manually created due to issues with `alembic.ini` detection in the environment, but are structured to integrate with an existing Alembic setup.