### PR TITLE
Ensure demo_data_loader limits person creation

### DIFF
--- a/demo/load_config.json
+++ b/demo/load_config.json
@@ -23,5 +23,6 @@
   "chance_of_marriage_in_generation": 0.8,
   "max_retries": 3,
   "retry_delay_seconds": 5,
+  "max_total_persons": 100,
   "log_level": "INFO"
 }


### PR DESCRIPTION
This commit verifies and ensures that the `demo_data_loader.py` script has a mechanism to limit the total number of persons created during a single execution.

Key features:
- A `max_total_persons` configuration option is available in `load_config.json` and defaults to 100 in `DEFAULT_CONFIG`.
- The script tracks the number of persons created globally.
- Person creation is halted once the configured limit is reached, with appropriate logging.

This functionality was confirmed to be present in your existing codebase.